### PR TITLE
0.2.3: improve TBC Raidcomp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elie.rotenberg.io",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "elie.rotenberg.io",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@chakra-ui/react": "^1.6.2",
         "@emotion/react": "^11.4.0",
@@ -24,6 +24,7 @@
         "@types/styled-jsx": "^2.2.8",
         "chance": "^1.1.7",
         "classnames": "^2.3.1",
+        "fast-deep-equal": "^3.1.3",
         "framer-motion": "^4.1.17",
         "gray-matter": "^4.0.3",
         "json-url": "^3.0.0",
@@ -6156,8 +6157,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
       "version": "1.2.0",
@@ -19709,8 +19709,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elie.rotenberg.io",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "ANALYZE_BUNDLE=0 next dev",
@@ -31,6 +31,7 @@
     "@types/styled-jsx": "^2.2.8",
     "chance": "^1.1.7",
     "classnames": "^2.3.1",
+    "fast-deep-equal": "^3.1.3",
     "framer-motion": "^4.1.17",
     "gray-matter": "^4.0.3",
     "json-url": "^3.0.0",

--- a/src/components/TbcRaidcomp/ert.lua
+++ b/src/components/TbcRaidcomp/ert.lua
@@ -3550,7 +3550,9 @@ function encode(gdocString)
 
 end
 
-local input = "$$__INPUT__$$"
+local js = require "js"
+
+local input = js.global.fengari.ert_lua_input
 
 encoded = encode(input)
 

--- a/src/lib/useDeepMemo.ts
+++ b/src/lib/useDeepMemo.ts
@@ -1,0 +1,14 @@
+import deepEqual from "fast-deep-equal";
+import { DependencyList, useEffect, useState } from "react";
+
+export const useDeepMemo = <T>(fn: () => T, deps: DependencyList): T => {
+  const [state, setState] = useState<[DependencyList, T]>(() => [deps, fn()]);
+
+  useEffect(() => {
+    if (!deepEqual(deps, state[0])) {
+      setState([deps, fn()]);
+    }
+  }, deps);
+
+  return state[1];
+};

--- a/src/lib/useLocationHash.ts
+++ b/src/lib/useLocationHash.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export const useLocationHash = (): null | string => {
+  const [hash, setHash] = useState<null | string>(null);
+
+  useEffect(() => {
+    const onChangeHash = (): void => {
+      if (typeof window !== `undefined`) {
+        setHash(window.location.hash.slice(1));
+      }
+    };
+    window.addEventListener(`hashchange`, onChangeHash);
+    onChangeHash();
+    return () => {
+      window.removeEventListener(`hashchange`, onChangeHash);
+    };
+  }, []);
+
+  return hash;
+};


### PR DESCRIPTION
* Display groups before roster
* Add undo/redo stack using location hash
* Improve wowhead URL parsing, automatically upsert characters
  not present or not identical in the current roster.
  Fixes #16, #17
* Pass input to lua script though the stack instead of an unsafe
  string potentially vulnerable to injection
* Use fixed-length groups array with offset indices for resilience
  and simplicity